### PR TITLE
Fix display of some terms in derivation trees

### DIFF
--- a/src/Language/Prolog/GraphViz/Formatting.hs
+++ b/src/Language/Prolog/GraphViz/Formatting.hs
@@ -5,7 +5,8 @@ module Language.Prolog.GraphViz.Formatting
   , legacyStyle
   ) where
 
-import Language.Prolog (Unifier, Goal)
+import Language.Prolog (Unifier, Goal, Term(Struct))
+import Data.Char (isAlphaNum)
 import Data.GraphViz.Attributes.HTML (TextItem (..))
 import qualified Data.Text.Lazy
 import Data.List (intercalate, intersperse)
@@ -52,7 +53,14 @@ resolutionStyle = GraphFormatting
 
 goalSet :: [Goal] -> TextItem
 goalSet xs = textItem $
-  "{"++ intercalate ", " (("¬"++). show <$> xs) ++"}"
+  "{"++ intercalate ", " (map format xs) ++"}"
+  where
+    format term = case term of
+      Struct "false" _ -> "false"
+      -- contains operator
+      Struct (c:_) _
+        | not (isAlphaNum c) -> "¬(" ++ show term ++ ")"
+      _ -> "¬" ++ show term
 
 goalQuery :: [Goal] -> TextItem
 goalQuery xs = textItem $

--- a/src/Language/Prolog/GraphViz/Formatting.hs
+++ b/src/Language/Prolog/GraphViz/Formatting.hs
@@ -55,12 +55,11 @@ goalSet :: [Goal] -> TextItem
 goalSet xs = textItem $
   "{"++ intercalate ", " (map format xs) ++"}"
   where
-    format term = case term of
-      Struct "false" _ -> "false"
-      -- contains operator
-      Struct (c:_) _
-        | not (isAlphaNum c) -> "¬(" ++ show term ++ ")"
-      _ -> "¬" ++ show term
+    format (Struct "false" _) = "false"
+    -- contains operator
+    format term@(Struct (c:_) _)
+      | not (isAlphaNum c) = "¬(" ++ show term ++ ")"
+    format term = "¬" ++ show term
 
 goalQuery :: [Goal] -> TextItem
 goalQuery xs = textItem $

--- a/src/Language/Prolog/GraphViz/Formatting.hs
+++ b/src/Language/Prolog/GraphViz/Formatting.hs
@@ -55,10 +55,10 @@ goalSet :: [Goal] -> TextItem
 goalSet xs = textItem $
   "{"++ intercalate ", " (map format xs) ++"}"
   where
-    format (Struct "false" _) = "false"
+    format (Struct "false" _) = "true"
     -- contains operator
-    format term@(Struct (c:_) _)
-      | not (isAlphaNum c) = "¬(" ++ show term ++ ")"
+    format term@(Struct atom@(c:_) _)
+      | not (isAlphaNum c) || atom == "is" = "¬(" ++ show term ++ ")"
     format term = "¬" ++ show term
 
 goalQuery :: [Goal] -> TextItem


### PR DESCRIPTION
Current display:

<img width="2170" height="1219" alt="Screenshot From 2025-12-04 12-04-42" src="https://github.com/user-attachments/assets/19210d98-2ea9-4701-991f-369b7d70ebf5" />

Adjusted display (the predicate is only incidentally named the same):

<img width="359" height="311" alt="test" src="https://github.com/user-attachments/assets/d2f6341d-6401-4fc7-a460-0c85b012919c" />


up for discussion:

- Should the evaluated `false` be displayed in some other way instead?
- Do we need to also bracket terms containing word-like operators (is, as, xor, etc.)

