### PR TITLE
use more subdued colours

### DIFF
--- a/src/Language/Prolog/GraphViz.hs
+++ b/src/Language/Prolog/GraphViz.hs
@@ -182,20 +182,20 @@ formatNode GraphFormatting{..} ((_,(_,u',[])), _, WasNotCut,_) = -- Success
     [] -> [ toLabel ("" :: String)
           , Complete.Width 0.2
           , Regular True
-          , Complete.Color [WC (X11Color Green) Nothing]
+          , Complete.Color [WC (X11Color ForestGreen) Nothing]
           ]
-    uf -> [ toLabel $ colorize Green $ formatSolution uf
-          , Complete.Color [WC (X11Color Green) Nothing]
+    uf -> [ toLabel $ colorize ForestGreen $ formatSolution uf
+          , Complete.Color [WC (X11Color ForestGreen) Nothing]
           ]
 formatNode GraphFormatting{..} ((_,(_,_,gs')), [], WasNotCut,GoalNotVisited) = -- Not visited
     [ Shape BoxShape
-    , toLabel $ colorize Orange [formatGoals gs']
-    , Complete.Color [WC (X11Color Orange) Nothing]
+    , toLabel $ colorize DarkOrange1 [formatGoals gs']
+    , Complete.Color [WC (X11Color DarkOrange1) Nothing]
     ]
 formatNode GraphFormatting{..} ((_,(_,_,gs')), [], WasNotCut,_) = -- Failure
     [ Shape BoxShape
-    , toLabel $ colorize Red [formatGoals gs']
-    , Complete.Color [WC (X11Color Red) Nothing]
+    , toLabel $ colorize Firebrick [formatGoals gs']
+    , Complete.Color [WC (X11Color Firebrick) Nothing]
     ]
 formatNode GraphFormatting{..} ((_,(_,_,gs')), _, WasNotCut,_) =
     [ Shape BoxShape, toLabel [formatGoals gs'] ]
@@ -205,15 +205,15 @@ formatNode GraphFormatting{..} ((_,(_,u',[])), _, WasCut,_) = -- Cut with Succee
     [] -> [ toLabel ("" :: String)
           , Complete.Width 0.2
           , Regular True
-          , Complete.Color [WC (X11Color Gray) Nothing]
+          , Complete.Color [WC (X11Color SlateGray) Nothing]
           ]
-    uf -> [ toLabel $ colorize Gray $ formatUnifier uf
-          , Complete.Color [WC (X11Color Gray) Nothing]
+    uf -> [ toLabel $ colorize SlateGray $ formatUnifier uf
+          , Complete.Color [WC (X11Color SlateGray) Nothing]
           ]
 formatNode GraphFormatting{..} ((_,(_,_,gs')), _, WasCut,_) = -- Cut
     [ Shape BoxShape
-    , toLabel $ colorize Gray [formatGoals gs']
-    , Complete.Color [WC (X11Color Gray) Nothing]
+    , toLabel $ colorize SlateGray [formatGoals gs']
+    , Complete.Color [WC (X11Color SlateGray) Nothing]
     ]
 
 


### PR DESCRIPTION
closes #7

I chose less bright shades for Red, Green and Gray. The Gray used previously was not hard on the eyes, but instead a bit hard to read on a white background.


### before

<img width="1021" height="529" alt="orig_cols" src="https://github.com/user-attachments/assets/2bfaba6f-1354-489d-a6cb-4480dfa844d8" />

### after

<img width="1021" height="529" alt="new_cols" src="https://github.com/user-attachments/assets/cd50a983-92d8-4e3e-8542-18a815033afe" />

There is also an Orange colour, but I wasn't able to trigger it, no matter what the query was. It is annotated as "Not visited" / `(WasNotCut,GoalNotVisited)`. I replaced it with a darker shade as well (query used here to demonstrate the colour choice is normal failure):

### before

<img width="105" height="59" alt="orange" src="https://github.com/user-attachments/assets/3484bf96-f140-4875-85c1-78fea36d6d9c" />

### after

<img width="105" height="59" alt="darkorange1" src="https://github.com/user-attachments/assets/0f8f5adf-aedc-4e6a-9f6a-ffed8ea47728" />
