### PR TITLE
Make graph node style configurable

### DIFF
--- a/prolog-graph/Main.hs
+++ b/prolog-graph/Main.hs
@@ -2,19 +2,25 @@ module Main where
 
 import Language.Prolog (consult, parseQuery)
 import ParseArgs (parseArgs)
-import Language.Prolog.GraphViz (resolveTreeToFile,resolveFirstTreeToFile)
+import Language.Prolog.GraphViz (
+  resolveTreeToFileWith,
+  resolveFirstTreeToFileWith,
+  defaultFormatting,
+  resolutionStyle,
+  )
 import Text.Parsec (ParseError)
 import Data.Functor (void)
 
 main :: IO ()
 main = do
-   (queryString, files, output, onlyFirst) <- parseArgs
+   (queryString, files, output, setNotation, onlyFirst) <- parseArgs
    p <- concat <$> mapM ((abortOnError=<<) . consult) files
    q <- abortOnError $ parseQuery queryString
+   let style = if setNotation then resolutionStyle else defaultFormatting
    void $
     if onlyFirst
-      then resolveFirstTreeToFile output p q
-      else resolveTreeToFile output p q
+      then resolveFirstTreeToFileWith style output p q
+      else resolveTreeToFileWith style output p q
 
 abortOnError :: Either ParseError b -> IO b
 abortOnError = either (error . show) return

--- a/prolog-graph/ParseArgs.hs
+++ b/prolog-graph/ParseArgs.hs
@@ -11,6 +11,7 @@ data Options = Options
    , file  :: [String]
    , output :: String
    , positional :: [String]
+   , setNotation :: Bool
    , first_result :: Bool
    }
   deriving (Data, Typeable)
@@ -20,6 +21,7 @@ options = Options
   , file   = def &= typ "FILE"  &= help "Consult file before executing query"
   , output = "graph.png" &= typ "FILE"  &= help "Save generated image to file (default: 'graph.png')"
   , positional = def &= args &= typ "QUERY [FILE]..."
+  , setNotation = def &= help "Use set notation (default: Prolog notation)"
   , first_result = def &= help "Resolve only until the first success"
   }
   &= versionArg [ignore]
@@ -28,6 +30,6 @@ options = Options
 parseArgs = do
    opts <- getProgName >>= cmdArgs . ((options &=) . program)
    return $ case opts of
-      Options q fs o []      b -> (q, fs,      o,b)
-      Options _ fs o [q]     b -> (q, fs,      o,b)
-      Options _ fs o (q:fs') b -> (q, fs++fs', o,b)
+      Options q fs o []      setNotation b -> (q, fs,      o, setNotation, b)
+      Options _ fs o [q]     setNotation b -> (q, fs,      o, setNotation, b)
+      Options _ fs o (q:fs') setNotation b -> (q, fs++fs', o, setNotation, b)

--- a/prolog-graph/ParseArgs.hs
+++ b/prolog-graph/ParseArgs.hs
@@ -11,7 +11,7 @@ data Options = Options
    , file  :: [String]
    , output :: String
    , positional :: [String]
-   , setNotation :: Bool
+   , set_notation :: Bool
    , first_result :: Bool
    }
   deriving (Data, Typeable)
@@ -21,7 +21,7 @@ options = Options
   , file   = def &= typ "FILE"  &= help "Consult file before executing query"
   , output = "graph.png" &= typ "FILE"  &= help "Save generated image to file (default: 'graph.png')"
   , positional = def &= args &= typ "QUERY [FILE]..."
-  , setNotation = def &= help "Use set notation (default: Prolog notation)"
+  , set_notation = def &= help "Use set notation (default: Prolog notation)"
   , first_result = def &= help "Resolve only until the first success"
   }
   &= versionArg [ignore]

--- a/src/Language/Prolog/GraphViz.hs
+++ b/src/Language/Prolog/GraphViz.hs
@@ -4,9 +4,9 @@
 module Language.Prolog.GraphViz
   ( Graph
   , resolveTree, resolveFirstTree
-  , resolveTreePreview, resolveTreeToFile
-  , resolveFirstTreePreview, resolveFirstTreeToFile
-  , GraphFormatting(..), defaultFormatting
+  , resolveTreePreview
+  , resolveFirstTreePreview, resolveFirstTreeToFileWith
+  , GraphFormatting(..), defaultFormatting, resolutionStyle
   , resolveTreePreviewWith, resolveTreeToFileWith
   , asInlineSvg, asInlineSvgWith
   ) where
@@ -37,7 +37,7 @@ import Data.GraphViz.Attributes.Complete as Complete
   ( Attribute(Ordering,Shape,Color,Width,Regular), Shape(BoxShape), Order(OutEdges))
 
 import Language.Prolog
-import Language.Prolog.GraphViz.Formatting (GraphFormatting (..), defaultFormatting)
+import Language.Prolog.GraphViz.Formatting (GraphFormatting (..), defaultFormatting, resolutionStyle)
 
 resolveTree :: Program -> [Goal] -> Either String ([Unifier], Graph)
 resolveTree p q = runGraphGenT $ resolve_ p q
@@ -56,11 +56,8 @@ resolveTreePreview = resolveTreePreviewWith defaultFormatting
 resolveFirstTreePreview :: Program -> [Goal] -> IO ()
 resolveFirstTreePreview = resolveTreePreviewWith' resolveFirstTree defaultFormatting
 
-resolveTreeToFile :: FilePath -> Program -> [Goal] -> IO FilePath
-resolveTreeToFile = resolveTreeToFileWith defaultFormatting
-
-resolveFirstTreeToFile :: FilePath -> Program -> [Goal] -> IO FilePath
-resolveFirstTreeToFile = resolveTreeToFileWith' resolveFirstTree defaultFormatting
+resolveFirstTreeToFileWith :: GraphFormatting -> FilePath -> Program -> [Goal] -> IO FilePath
+resolveFirstTreeToFileWith = resolveTreeToFileWith' resolveFirstTree
 
 asInlineSvg :: Graph -> IO B.ByteString
 asInlineSvg = asInlineSvgWith defaultFormatting


### PR DESCRIPTION
- default is current formatting (Prolog)
- using `set-notation` or `-s` switches to set notation
- removed unused functions `resolveFirstTreeToFile` and `resolveTreeToFile` (not used in Autotool or `prolog-programming-task`)
